### PR TITLE
Struct naming scheme

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -46,7 +46,7 @@ static const char *level_strings[] = {
 
 
 
-static void stdout_callback(log_Event *ev) {
+static void stdout_callback(LogEvent *ev) {
   char buf[16];
   buf[strftime(buf, sizeof(buf), "%H:%M:%S", ev->time)] = '\0';
 
@@ -64,7 +64,7 @@ static void stdout_callback(log_Event *ev) {
 }
 
 
-static void file_callback(log_Event *ev) {
+static void file_callback(LogEvent *ev) {
   char buf[64];
   buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", ev->time)] = '\0';
   fprintf(
@@ -128,7 +128,7 @@ int log_add_fp(FILE *fp, int level) {
 }
 
 
-static void init_event(log_Event *ev, void *udata) {
+static void init_event(LogEvent *ev, void *udata) {
   if (!ev->time) {
     time_t t = time(NULL);
     ev->time = localtime(&t);
@@ -138,7 +138,7 @@ static void init_event(log_Event *ev, void *udata) {
 
 
 void log_log(int level, const char *file, int line, const char *fmt, ...) {
-  log_Event ev = {
+  LogEvent ev = {
     .fmt   = fmt,
     .file  = file,
     .line  = line,

--- a/src/log.c
+++ b/src/log.c
@@ -24,7 +24,7 @@
 
 #define MAX_CALLBACKS 32
 
-typedef struct {
+typedef struct Callback {
   log_LogFn fn;
   void *udata;
   int level;

--- a/src/log.h
+++ b/src/log.h
@@ -28,7 +28,7 @@ typedef struct {
 typedef void (*log_LogFn)(log_Event *ev);
 typedef void (*log_LockFn)(bool lock, void *udata);
 
-enum { LOG_LEVEL_TRACE, LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARN, LOG_LEVEL_ERROR, LOG_LEVEL_FATAL };
+typedef enum LogLevel { LOG_LEVEL_TRACE, LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARN, LOG_LEVEL_ERROR, LOG_LEVEL_FATAL } LogLevel;
 
 #define LOG_TRACE(...) log_log(LOG_LEVEL_TRACE, __FILE__, __LINE__, __VA_ARGS__)
 #define LOG_DEBUG(...) log_log(LOG_LEVEL_DEBUG, __FILE__, __LINE__, __VA_ARGS__)

--- a/src/log.h
+++ b/src/log.h
@@ -15,7 +15,7 @@
 
 #define LOG_VERSION "0.1.0"
 
-typedef struct {
+typedef struct LogEvent {
   va_list ap;
   const char *fmt;
   const char *file;
@@ -23,9 +23,9 @@ typedef struct {
   void *udata;
   int line;
   int level;
-} log_Event;
+} LogEvent;
 
-typedef void (*log_LogFn)(log_Event *ev);
+typedef void (*log_LogFn)(LogEvent *ev);
 typedef void (*log_LockFn)(bool lock, void *udata);
 
 typedef enum LogLevel { LOG_LEVEL_TRACE, LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARN, LOG_LEVEL_ERROR, LOG_LEVEL_FATAL } LogLevel;


### PR DESCRIPTION
I thought it would be nice to be able to differentiate just from syntax between normal typedefs (like uint8_t) using Snakecase and enum, struct and union typedefs using Upper Camel Case.
Also, I think structs, enums and unions should be able to be referenced both with and without their keyword (`struct FooBar` and `FooBar`).

In particular, I changed three names in the project:
    1. `log_Event` to `LogEvent`
    2. Added `LogEvent` as name for enum of log levels
    3. Added the possiblity to reference `Callback` as `struct Callback`

Each one of this changes is implemented in different commits, for ease of review.

I hope you find value in this changes.  

Cheers!